### PR TITLE
Automatically updating posters

### DIFF
--- a/src/main/java/me/florestanii/pictureframe/MapHandler.java
+++ b/src/main/java/me/florestanii/pictureframe/MapHandler.java
@@ -1,17 +1,12 @@
 package me.florestanii.pictureframe;
 
-import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 
 public class MapHandler implements Runnable {
-    private final List<ItemStack> renderedMaps;
     private final Player player;
     private final PictureFrame plugin;
     private final String path;
@@ -20,7 +15,6 @@ public class MapHandler implements Runnable {
     private Callback callback;
 
     public MapHandler(Player player, String path, int width, int height, PictureFrame plugin) {
-        this.renderedMaps = new ArrayList<>(width * height);
         this.player = player;
         this.plugin = plugin;
         this.path = path;

--- a/src/main/java/me/florestanii/pictureframe/PictureFrame.java
+++ b/src/main/java/me/florestanii/pictureframe/PictureFrame.java
@@ -42,7 +42,6 @@ public class PictureFrame extends JavaPlugin {
     @Override
     public void onDisable() {
         savePosters();
-        super.onDisable();
     }
 
     public void loadPosters() {

--- a/src/main/java/me/florestanii/pictureframe/PictureFrame.java
+++ b/src/main/java/me/florestanii/pictureframe/PictureFrame.java
@@ -41,7 +41,7 @@ public class PictureFrame extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        saveMapConfig();
+        savePosters();
         super.onDisable();
     }
 
@@ -65,7 +65,7 @@ public class PictureFrame extends JavaPlugin {
         }
     }
 
-    public void saveMapConfig() {
+    public void savePosters() {
         List<Object> posterConfigs = new ArrayList<>();
 
         for (Poster poster : posters) {
@@ -103,7 +103,7 @@ public class PictureFrame extends JavaPlugin {
     public void addPoster(Poster poster) {
         posters.add(poster);
         registerUpdates(poster);
-        saveMapConfig();
+        savePosters();
     }
 
     private void registerUpdates(final Poster poster) {

--- a/src/main/java/me/florestanii/pictureframe/PictureFrame.java
+++ b/src/main/java/me/florestanii/pictureframe/PictureFrame.java
@@ -23,20 +23,18 @@ public class PictureFrame extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        posters.clear();
-
         if (!imagesDirectory.exists() && !imagesDirectory.mkdirs()) {
             getLogger().severe("No images directory found (and it couldn't be created automatically).");
             setEnabled(false);
             return;
         }
 
+        saveDefaultConfig();
+        loadPosters();
+
         getCommand("pictureframe").setExecutor(new PictureFrameCommand(this));
         getServer().getPluginManager().registerEvents(new ChunkListener(this), this);
         getServer().getPluginManager().registerEvents(new ProtectionListener(this), this);
-
-        saveDefaultConfig();
-        loadPosters();
     }
 
     @Override
@@ -44,7 +42,12 @@ public class PictureFrame extends JavaPlugin {
         savePosters();
     }
 
-    public void loadPosters() {
+    public void reload() {
+        loadPosters();
+    }
+
+    private void loadPosters() {
+        posters.clear();
         ConfigurationSection posterConfig = YamlConfiguration.loadConfiguration(mapConfigFile);
         int loadedMaps = 0;
         int failedMaps = 0;

--- a/src/main/java/me/florestanii/pictureframe/PictureFrameCommand.java
+++ b/src/main/java/me/florestanii/pictureframe/PictureFrameCommand.java
@@ -52,6 +52,10 @@ public class PictureFrameCommand implements CommandExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("reload") && sender.hasPermission("pictureframe.reload")) {
+            plugin.reload();
+        }
+
         sendHelp(p);
         return true;
     }

--- a/src/main/java/me/florestanii/pictureframe/SavedMap.java
+++ b/src/main/java/me/florestanii/pictureframe/SavedMap.java
@@ -2,65 +2,29 @@ package me.florestanii.pictureframe;
 
 import me.florestanii.pictureframe.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.World;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.map.MapPalette;
 import org.bukkit.map.MapView;
 
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
 
+/**
+ * A single map of a poster.
+ */
 public class SavedMap {
-    private PictureFrame plugin;
-    private String imgName;
-    private World world;
-    private short id;
+    private final short id;
     private BufferedImage image;
 
-    public SavedMap(PictureFrame plugin, short id, BufferedImage img, World world) {
-        this.plugin = plugin;
+    public SavedMap(short id) {
         this.id = id;
-        this.image = img;
-        this.imgName = ("map" + id);
-        this.world = world;
-    }
-
-    public SavedMap(PictureFrame plugin, short id) {
-        this.id = id;
-        this.plugin = plugin;
-        ConfigurationSection section = this.plugin.getMapConfig().getConfigurationSection("map" + id);
-        this.imgName = section.getString("image");
-        try {
-            this.image = ImageIO.read(new File(plugin.getScaledImagesDirectory(), this.imgName + ".png"));
-        } catch (IOException e) {
-            plugin.getLogger().log(Level.WARNING, "Could not load map image " + imgName + ".png", e);
-        }
-    }
-
-    public boolean saveMap() {
-        try {
-            File outputfile = new File(plugin.getScaledImagesDirectory(), imgName + ".png");
-            ImageIO.write(MapPalette.resizeImage(image), "png", outputfile);
-        } catch (IOException e) {
-            plugin.getLogger().log(Level.WARNING, "Could not save map image " + imgName + ".png", e);
-            return false;
-        }
-        ConfigurationSection section = plugin.getMapConfig().createSection(imgName);
-        section.set("id", id);
-        section.set("image", imgName);
-        plugin.saveMapConfig();
-        return true;
     }
 
     @SuppressWarnings("deprecation")
-    public boolean loadMap() {
+    private boolean updateMapRenderer() {
         MapView mapView = Bukkit.getMap(id);
         if (mapView != null) {
             Util.removeAllRenderers(mapView);
-            mapView.addRenderer(new ImageMapRenderer(image));
+            if (image != null) {
+                mapView.addRenderer(new ImageMapRenderer(image));
+            }
             return true;
         }
         return false;
@@ -70,7 +34,8 @@ public class SavedMap {
         return id;
     }
 
-    public void updateImage(BufferedImage image) {
+    public boolean setImage(BufferedImage image) {
         this.image = image;
+        return updateMapRenderer();
     }
 }

--- a/src/main/java/me/florestanii/pictureframe/SavedMap.java
+++ b/src/main/java/me/florestanii/pictureframe/SavedMap.java
@@ -11,7 +11,6 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
 import java.util.logging.Level;
 
 public class SavedMap {
@@ -32,18 +31,12 @@ public class SavedMap {
     public SavedMap(PictureFrame plugin, short id) {
         this.id = id;
         this.plugin = plugin;
-        Set<String> keys = this.plugin.getMapConfig().getKeys(false);
-        for (String key : keys) {
-            if (key.equals("map" + id)) {
-                ConfigurationSection section = plugin.getMapConfig().getConfigurationSection(key);
-
-                this.imgName = section.getString("image");
-                try {
-                    this.image = ImageIO.read(new File(plugin.getScaledImagesDirectory(), this.imgName + ".png"));
-                } catch (IOException e) {
-                    plugin.getLogger().log(Level.WARNING, "Could not load map image " + imgName + ".png", e);
-                }
-            }
+        ConfigurationSection section = this.plugin.getMapConfig().getConfigurationSection("map" + id);
+        this.imgName = section.getString("image");
+        try {
+            this.image = ImageIO.read(new File(plugin.getScaledImagesDirectory(), this.imgName + ".png"));
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.WARNING, "Could not load map image " + imgName + ".png", e);
         }
     }
 
@@ -72,12 +65,12 @@ public class SavedMap {
         }
         return false;
     }
-    public short getId(){
-    	return id;
+
+    public short getId() {
+        return id;
     }
-    
-    public void updateImage(BufferedImage image){
-    	this.image = image;
+
+    public void updateImage(BufferedImage image) {
+        this.image = image;
     }
-    
 }

--- a/src/main/java/me/florestanii/pictureframe/listener/ProtectionListener.java
+++ b/src/main/java/me/florestanii/pictureframe/listener/ProtectionListener.java
@@ -1,7 +1,6 @@
 package me.florestanii.pictureframe.listener;
 
 import me.florestanii.pictureframe.PictureFrame;
-
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
@@ -12,7 +11,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public class ProtectionListener implements Listener{
-
 	private final PictureFrame plugin;
 	
 	public ProtectionListener(PictureFrame plugin){
@@ -35,7 +33,6 @@ public class ProtectionListener implements Listener{
 			event.setCancelled(true);
 			return;
 		}
-		
 	}
 	
 	@EventHandler
@@ -61,7 +58,5 @@ public class ProtectionListener implements Listener{
 			event.setCancelled(true);
 			return;
 		}
-		
 	}
-	
 }

--- a/src/main/java/me/florestanii/pictureframe/util/Util.java
+++ b/src/main/java/me/florestanii/pictureframe/util/Util.java
@@ -4,9 +4,16 @@ import org.bukkit.Material;
 import org.bukkit.Rotation;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.map.MapView;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 public class Util {
     public static void attachItemFrame(Block block, ItemStack map, BlockFace face) {
@@ -37,5 +44,20 @@ public class Util {
         for (int i = 0; i < map.getRenderers().size(); i++) {
             map.removeRenderer(map.getRenderers().get(i));
         }
+    }
+
+    public static List<ConfigurationSection> getConfigList(ConfigurationSection config, String path) {
+        if (!config.isList(path)) {
+            return Collections.emptyList();
+        }
+
+        List<ConfigurationSection> list = new LinkedList<>();
+        for (Map object : config.getMapList(path)) {
+            MemoryConfiguration mc = new MemoryConfiguration();
+            mc.addDefaults(object);
+            list.add(mc);
+        }
+
+        return list;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+updateInterval: 3600

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,23 @@ version: VERSION
 
 commands:
   pictureframe:
-     descripton: PictureFrame command
-     usage: / <commands> <args>
-     aliases: [pf]
+    descripton: PictureFrame command
+    usage: / <commands> <args>
+    aliases: [pf]
+
+permissions:
+  pictureframe.create:
+    description: Players with this permission may create 1x1 posters
+    default: op
+  pictureframe.multicreate:
+    description: Players with this permission may create large posters
+    default: op
+  pictureframe.reload:
+    description: Players with this permission may reload the plugin
+    default: op
+  pictureframe.interact:
+    description: Players with this permission may interact with maps of posters (i.e. rotate them)
+    default: op
+  pictureframe.destroy:
+    description: Players with this permission may destroy posters
+    default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,10 +8,3 @@ commands:
      descripton: PictureFrame command
      usage: / <commands> <args>
      aliases: [pf]
-  tomap:
-    description: render an image in a map
-    usage: /<command> [URL]
-  maptool:
-    description: manage maps
-    usage: /<command>
-      

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ version: VERSION
 commands:
   pictureframe:
     descripton: PictureFrame command
-    usage: / <commands> <args>
+    usage: /pictureframe <command> <args>
     aliases: [pf]
 
 permissions:


### PR DESCRIPTION
This pull request changes the way PictureFrame handles images (in a manner that breaks compatibility with the previous version): Instead of managing single maps, it now manages entire posters, leading to a higher level of abstraction.
These changes allow PictureFrame to update entire posters at once, which it now does by default for every poster.
I also dropped the command to register maps for updates as it's not needed anymore.

Note that right now, it is not possible to download an image only once. All images will always be updated from their original sources. This shouldn't be a problem in most cases, though.
